### PR TITLE
Removed the no longer available :host selector and added syntax-- to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brogrammer-syntax theme
 
-Atom syntax theme to match the brogrammer-ui theme
+Atom syntax theme to match the brogrammer-harder-ui theme
 
 Preview:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Atom syntax theme to match the brogrammer-ui theme
 
-Preview: 
+Preview:
 
 ![Preview](http://i.imgur.com/sX0OWz2.png)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "brogrammer-syntax",
+  "name": "brogrammer-harder-syntax",
   "theme": "syntax",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "description": "A twice updated fork of the Brogrammer syntax theme for atom",
-  "repository": "https://github.com/apedley/brogrammer-syntax",
+  "repository": "https://github.com/apedley/brogrammer-harder-syntax",
   "license": "MIT",
   "keywords": [
     "dark",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "brogrammer-syntax",
   "theme": "syntax",
-  "version": "1.0.0",
-  "private": true,
-  "description": "A short description of your theme",
-  "repository": "https://github.com/kenwheeler/brogrammer-syntax",
+  "version": "1.0.2",
+  "description": "A twice updated fork of the Brogrammer syntax theme for atom",
+  "repository": "https://github.com/apedley/brogrammer-syntax",
   "license": "MIT",
+  "keywords": [
+    "dark",
+    "flat",
+    "brogrammer"
+  ],
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brogrammer-harder-syntax",
   "theme": "syntax",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A twice updated fork of the Brogrammer syntax theme for atom",
   "repository": "https://github.com/apedley/brogrammer-harder-syntax",
   "license": "MIT",

--- a/styles/base.less
+++ b/styles/base.less
@@ -5,12 +5,12 @@
 @import "ui-variables";
 @import "colors";
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @base03;
   color: @base0;
 }
 
-atom-text-editor, :host {
+atom-text-editor {
   .invisible-character,
   .indent-guide {
     color: @base01;
@@ -45,78 +45,78 @@ atom-text-editor, :host {
   }
 }
 
-.bracket-matcher .region {
+.syntax--bracket-matcher .syntax--region {
   background-color: @base1;
   opacity: 0.7;
 }
 
-.comment {
+.syntax--comment {
   color: @base05;
   font-style: italic;
 }
 
-.entity {
+.syntax--entity {
   color: @green;
 }
 
-.keyword {
+.syntax--keyword {
   color: @red;
 }
 
-.any-method {
+.syntax--any-method {
   color: @blue;
 }
 
-.storage.type {
+.syntax--storage.syntax--type {
   color: @blue;
 }
 
-.storage.modifier {
+.syntax--storage.syntax--modifier {
   color: @red;
 }
 
-.constant {
+.syntax--constant {
   color: @violet;
 
-  &.numeric,
-  &.boolean {
+  &.syntax--numeric,
+  &.syntax--boolean {
     color: @green;
   }
 }
 
-.variable {
+.syntax--variable {
   color: #fff;
 }
 
-.delimiter, .brace {
+.syntax--delimiter, .syntax--brace {
   color: @base0;
 }
 
-.delimiter.period {
+.syntax--delimiter.syntax--period {
   color: @green;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   text-decoration: underline;
   color: @red;
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: @red;
 }
 
-.string {
+.syntax--string {
   color: @yellow;
 
-  .constant.character.escape {
+  .syntax--constant.syntax--character.syntax--escape {
     color: @red;
   }
 
-  &.regexp {
+  &.syntax--regexp {
     color: @blue;
 
-    .source.ruby.embedded,
-    .string.regexp.arbitrary-repitition {
+    .syntax--source.syntax--ruby.syntax--embedded,
+    .syntax--string.syntax--regexp.syntax--arbitrary-repitition {
       color: @red;
     }
   }


### PR DESCRIPTION
…all grammar selectors

:host is gone and atom recommends removing it. They are requiring every grammar selector to be prefixed with syntax-- as well. This was also throwing warnings.